### PR TITLE
set prod type on open search

### DIFF
--- a/routes/productRoutes.ts
+++ b/routes/productRoutes.ts
@@ -57,6 +57,8 @@ function buildProductsQuery(parms: IProductFilters, fuzzy = false): Query<IProdu
       // Do text search by default
       productQuery.where({ type: searchType, $text: { $search: queryString } });
     }
+  } else {
+    productQuery.where({ type: searchType });
   }
 
   return productQuery;


### PR DESCRIPTION
make sure product type is set when performing an wide-open search (no query)